### PR TITLE
Added ability to connect to pre-existing kernel

### DIFF
--- a/packages/react/src/jupyter/Jupyter.tsx
+++ b/packages/react/src/jupyter/Jupyter.tsx
@@ -37,6 +37,7 @@ export type JupyterProps = {
   lite: boolean;
   startDefaultKernel: boolean;
   defaultKernelName: string;
+  selectRunningKernel?: boolean;
   injectableStore?: Store | any;
   collaborative?: boolean;
   jupyterServerHttpUrl?: string;
@@ -80,6 +81,7 @@ export const Jupyter = (props: JupyterProps) => {
             lite={lite}
             startDefaultKernel={startDefaultKernel}
             defaultKernelName={defaultKernelName}
+            selectRunningKernel={props?.selectRunningKernel ?? false}
             baseUrl={getJupyterServerHttpUrl()}
             wsUrl={getJupyterServerWsUrl()}
             injectableStore={props.injectableStore || injectableStore}
@@ -97,6 +99,7 @@ Jupyter.defaultProps = {
   lite: false,
   defaultKernelName: 'python',
   startDefaultKernel: true,
+  selectRunningKernel: false,
   collaborative: false,
   terminals: false,
 }

--- a/packages/react/src/jupyter/JupyterContext.tsx
+++ b/packages/react/src/jupyter/JupyterContext.tsx
@@ -16,6 +16,7 @@ export type JupyterContextType = {
   kernelManager?: KernelManager,
   defaultKernel?: Kernel,
   startDefaultKernel: boolean,
+  selectRunningKernel?: boolean,
   variant: string;
   setVariant: (value: string) => void;
   baseUrl: string;
@@ -68,6 +69,7 @@ type JupyterContextProps = {
   wsUrl: string;
   lite: boolean;
   startDefaultKernel: boolean,
+  selectRunningKernel: boolean,
   defaultKernelName: string,
   injectableStore: any;
 };
@@ -101,11 +103,12 @@ export const JupyterContextProvider: React.FC<{
   lite: boolean,
   startDefaultKernel: boolean,
   defaultKernelName: string,
+  selectRunningKernel: boolean,
   variant: string,
   baseUrl: string,
   wsUrl: string,
   injectableStore: any
-}> = ({children, lite, startDefaultKernel, defaultKernelName, variant, baseUrl, wsUrl, injectableStore }: JupyterContextProps) => {
+}> = ({children, lite, startDefaultKernel, defaultKernelName, selectRunningKernel, variant, baseUrl, wsUrl, injectableStore }: JupyterContextProps) => {
   const [_, setVariant] = useState('default');
   const [serverSettings] = useState<ServerConnection.ISettings>(createServerSettings(baseUrl, wsUrl));
   const [serviceManager, setServiceManager] = useState<ServiceManager>();
@@ -120,7 +123,7 @@ export const JupyterContextProvider: React.FC<{
         kernelManager.ready.then(() => {
           console.log('Kernel Manager is ready', kernelManager);
           if (startDefaultKernel) {
-            const kernel = new Kernel({ kernelManager, kernelName: defaultKernelName });
+            const kernel = new Kernel({ kernelManager, kernelName: defaultKernelName, selectRunningKernel: selectRunningKernel });
             kernel.getJupyterKernel().then(k => {
               console.log(`Kernel started with session client_id:id ${k.clientId}:${k.id}`);
               k.info.then(info => {
@@ -145,7 +148,7 @@ export const JupyterContextProvider: React.FC<{
         kernelManager.ready.then(() => {
           console.log('Kernel Manager is ready', kernelManager);
           if (startDefaultKernel) {
-            const kernel = new Kernel({ kernelManager, kernelName: defaultKernelName });
+            const kernel = new Kernel({ kernelManager, kernelName: defaultKernelName, selectRunningKernel: selectRunningKernel  });
             kernel.getJupyterKernel().then(k => {
               console.log(`Kernel started with session client_id:id ${k.clientId}:${k.id}`);
               k.info.then(info => {


### PR DESCRIPTION
Hey there, this is a really neat library thanks for writing it.

I've been working on an app that needs to connect to a preexisting kernel instead of starting a new one on connect. I've made a small modification to allow a prop to pass through to your Kernal wrapper, search for pre running kernels and select them.

To be honest I'm not that happy with the implementation, as it seems your code is aligned with the standard Jupyter codebase, and this does seem to deviate from that. So other than asking to bring in this prop, I wanted to ask is there a better way to approach this?