### PR TITLE
fix keyboad event cleanup

### DIFF
--- a/packages/react/src/components/notebook/Notebook.tsx
+++ b/packages/react/src/components/notebook/Notebook.tsx
@@ -198,12 +198,11 @@ export const Notebook = (props: INotebookProps) => {
     injectableStore.inject('notebook', notebookReducer, notebookEpics);
   }, []);
   useEffect(() => {
+    if (adapter) {
+      adapter.dispose();
+    }
     newAdapterState();
     return () => {
-      if (adapter) {
-        adapter.dispose();
-      }
-      setAdapter(undefined);
       dispatch(
         notebookActions.setPortalDisplay({ uid, portalDisplay: undefined })
       );

--- a/packages/react/src/components/notebook/NotebookAdapter.ts
+++ b/packages/react/src/components/notebook/NotebookAdapter.ts
@@ -136,16 +136,14 @@ export class NotebookAdapter {
     });
   }
 
+  notebookKeydownListener = (event: KeyboardEvent) => {
+    this._commandRegistry?.processKeydownEvent(event);
+  }
+
   private setupAdapter(): void {
     const useCapture = true;
 
-    document.addEventListener(
-      'keydown',
-      event => {
-        this._commandRegistry?.processKeydownEvent(event);
-      },
-      useCapture
-    );
+    document.addEventListener( 'keydown', this.notebookKeydownListener, useCapture);
 
     const initialFactories = standardRendererFactories.filter(
       factory => factory.mimeTypes[0] !== 'text/javascript'
@@ -611,6 +609,7 @@ export class NotebookAdapter {
   };
 
   dispose = () => {
+    document.removeEventListener('keydown', this.notebookKeydownListener, true);
     //    this._boxPanel.dispose();
     //    this._notebookPanel?.dispose();
     //    this._context?.dispose();


### PR DESCRIPTION
This is a suggested fix for https://github.com/datalayer/jupyter-ui/issues/219#issue-2300634048

The problem seems to be that each time the NotebookAdapter is created a new keydown event listener is added to the document. This means that keyboard command like `shift-enter` don't work if you modify the notebook by changing the `path` or `nbformat` parameters.

Although the modified useEffect function in Notebook.tsx had a call to the adapter cleanup function, this was never called because in my testing `adapter` was always undefined by the time the useEffect cleanup function was executed.

Instead we call adapter.cleanup() in the main part of useEffect, which will still have a reference to the previous adapter before it creates the new one.

I don't understand the full codebase enough to know if that has any other deleterious side effects, but it fixes the bug reported in the issue above.

Here's a gif of the NotebookPathChange.tsx example being run after this fix:

![notebook](https://github.com/datalayer/jupyter-ui/assets/3999743/6045a3ff-faad-4467-a6ba-bb63b31055e8)
