### PR TITLE
Implemented show\hide kernel progress bar for Output

### DIFF
--- a/packages/react/src/components/output/Output.tsx
+++ b/packages/react/src/components/output/Output.tsx
@@ -37,6 +37,7 @@ export type IOutputProps = {
   receipt?: string;
   showControl?: boolean;
   showEditor: boolean;
+  showKernelProgressBar?: boolean;
   sourceId: string;
   toolbarPosition: 'up' | 'middle' | 'none';
 };
@@ -58,6 +59,7 @@ export const Output = (props: IOutputProps) => {
     receipt,
     showControl,
     showEditor,
+    showKernelProgressBar,
     sourceId,
     toolbarPosition,
   } = props;
@@ -166,7 +168,7 @@ export const Output = (props: IOutputProps) => {
       {adapter && (
         <Box display="flex">
           <Box flexGrow={1}>
-            {kernelStatus !== 'idle' && <KernelProgressBar />}
+            {kernelStatus !== 'idle' && showKernelProgressBar && <KernelProgressBar />}
           </Box>
           {showControl && (
             <Box style={{ marginTop: '-13px' }}>

--- a/packages/react/src/components/output/Output.tsx
+++ b/packages/react/src/components/output/Output.tsx
@@ -59,7 +59,7 @@ export const Output = (props: IOutputProps) => {
     receipt,
     showControl,
     showEditor,
-    showKernelProgressBar,
+    showKernelProgressBar = true,
     sourceId,
     toolbarPosition,
   } = props;


### PR DESCRIPTION
Kernel progress bar that is visible by default when kernel is not idle looks very strange.

In fact when we execute just one output - EVERY output on the page shows some progress which seems very strange and misleading for me, because I triggered execution of only one specific output

Another issue with this progress bar is it shows progress when kernel is not executing anything AND is not 'idle'. I guess in that state kernel tries to initialize or smth like this but user is seeing some progress which also looks misleading for me

IMHO In any case there must be a chance to hide this progress and replace it by smth else, like with controls and editor