### PR TITLE
Control session and kernel initialization individually per Cell

### DIFF
--- a/packages/react/src/components/cell/Cell.tsx
+++ b/packages/react/src/components/cell/Cell.tsx
@@ -6,7 +6,6 @@
 
 import { useState, useEffect } from 'react';
 import { CodeCell, MarkdownCell } from '@jupyterlab/cells';
-import { KernelMessage } from '@jupyterlab/services';
 import { Box } from '@primer/react';
 import CellAdapter from './CellAdapter';
 import Lumino from '../lumino/Lumino';
@@ -60,23 +59,24 @@ export const Cell = (props: ICellProps) => {
     }
 
     adapter.sessionContext.initialize().then(() => {
-      if (!autoStart || !adapter.cell.model) {
-        return
+      if (!adapter.cell.model) {
+        return;
       }
-
+      // Set that session/kernel is ready for that cell
+      cellStore.setKernelAvailable(id, true);
+    
       // Perform auto-start for code or markdown cells
-      if (adapter.cell instanceof CodeCell) {
-        const execute = CodeCell.execute(
-          adapter.cell,
-          adapter.sessionContext
-        );
-        execute.then((msg: void | KernelMessage.IExecuteReplyMsg) => {
-          cellStore.setKernelAvailable(true);
-        });
-      }
+      if (autoStart) {
+        if (adapter.cell instanceof CodeCell) {
+          CodeCell.execute(
+            adapter.cell,
+            adapter.sessionContext
+          );
+        }
 
-      if (adapter.cell instanceof MarkdownCell) {
-        adapter.cell.rendered = true;
+        if (adapter.cell instanceof MarkdownCell) {
+          adapter.cell.rendered = true;
+        }
       }
     });
   }

--- a/packages/react/src/components/cell/Cell.tsx
+++ b/packages/react/src/components/cell/Cell.tsx
@@ -59,25 +59,28 @@ export const Cell = (props: ICellProps) => {
     }
 
     adapter.sessionContext.initialize().then(() => {
-      if (!adapter.cell.model) {
+      if (!autoStart || !adapter.cell.model) {
         return;
       }
-      // Set that session/kernel is ready for that cell
-      cellStore.setKernelAvailable(id, true);
     
       // Perform auto-start for code or markdown cells
-      if (autoStart) {
-        if (adapter.cell instanceof CodeCell) {
-          CodeCell.execute(
-            adapter.cell,
-            adapter.sessionContext
-          );
-        }
-
-        if (adapter.cell instanceof MarkdownCell) {
-          adapter.cell.rendered = true;
-        }
+      if (adapter.cell instanceof CodeCell) {
+        CodeCell.execute(
+          adapter.cell,
+          adapter.sessionContext
+        );
       }
+
+      if (adapter.cell instanceof MarkdownCell) {
+        adapter.cell.rendered = true;
+      }
+    });
+
+    adapter.sessionContext.kernelChanged.connect(() => {
+      void adapter.sessionContext.session?.kernel?.info.then(info => {
+        // Set that session/kernel is ready for this cell when the kernel is guaranteed to be connected 
+        cellStore.setKernelAvailable(id, true);
+      })
     });
   }
 

--- a/packages/react/src/components/cell/Cell.tsx
+++ b/packages/react/src/components/cell/Cell.tsx
@@ -79,7 +79,7 @@ export const Cell = (props: ICellProps) => {
     adapter.sessionContext.kernelChanged.connect(() => {
       void adapter.sessionContext.session?.kernel?.info.then(info => {
         // Set that session/kernel is ready for this cell when the kernel is guaranteed to be connected 
-        cellStore.setKernelAvailable(id, true);
+        cellStore.setIsKernelSessionAvailable(id, true);
       })
     });
   }

--- a/packages/react/src/components/cell/CellAdapter.ts
+++ b/packages/react/src/components/cell/CellAdapter.ts
@@ -268,7 +268,9 @@ export class CellAdapter {
         if (this._type === 'code') {
           const lang = info.language_info;
           const mimeType = mimeService.getMimeTypeByLanguage(lang);
-          this._cell.model.mimeType = mimeType;
+          if (this._cell.model) {
+            this._cell.model.mimeType = mimeType;
+          } 
         }
       });
     });

--- a/packages/react/src/components/cell/CellState.ts
+++ b/packages/react/src/components/cell/CellState.ts
@@ -12,33 +12,33 @@ export interface ICellState {
   source?: string;
   outputsCount?: number;
   adapter?: CellAdapter;
-  kernelAvailable?: boolean;
+  isKernelSessionAvailable?: boolean; // Individual, for cell
 }
 
 export interface ICellsState {
   cells: Map<string, ICellState>;
-  areAllCellsReady: boolean;
+  areAllKernelSessionsReady: boolean; // Control the state for all cells
 }
 
 export type CellState = ICellsState & {
   setCells: (cells: Map<string, ICellState>) => void;
   setSource: (id: string, source: string) => void;
   setOutputsCount: (id: string, outputsCount: number) => void;
-  setKernelAvailable: (id: string, kernelAvailable: boolean) => void;
+  setIsKernelSessionAvailable: (id: string, kernelAvailable: boolean) => void;
   setAdapter: (id: string, adapter?: CellAdapter) => void;
   getAdapter: (id: string) => CellAdapter | undefined;
   getSource: (id: string) => string | undefined;
   getOutputsCount: (id: string) => number | undefined;
-  getIsKernelAvailable: (id: string) => boolean | undefined;
+  getIsKernelSessionAvailable: (id: string) => boolean | undefined;
   execute: (id?: string) => void;
 };
 
 /**
  * Iterate over all cells map and check if all cells/sessions are ready
  */
-const areAllSessionsAvailable = (cells: Map<string, ICellState>): boolean => {
+const areAllKernelSessionsAvailable = (cells: Map<string, ICellState>): boolean => {
   for (const cell of cells.values()) {
-    if (!cell.kernelAvailable) {
+    if (!cell.isKernelSessionAvailable) {
       return false;
     }
   }
@@ -49,8 +49,8 @@ export const cellStore = createStore<CellState>((set, get) => ({
   cells: new Map<string, ICellState>(),
   source: '',
   outputsCount: 0,
-  kernelAvailable: false,
-  areAllCellsReady: false,
+  isKernelSessionAvailable: false,
+  areAllKernelSessionsReady: false,
   adapter: undefined,
   setCells: (cells: Map<string, ICellState>) => set((cell: CellState) => ({ cells })),
 
@@ -74,16 +74,16 @@ export const cellStore = createStore<CellState>((set, get) => ({
     }
     set((state: CellState) => ({ cells }))
   },
-  setKernelAvailable: (id: string, kernelAvailable: boolean) => {
+  setIsKernelSessionAvailable: (id: string, isKernelSessionAvailable: boolean) => {
     const cells = get().cells;
     const cell = cells.get(id);
     if (cell) {
-      cell.kernelAvailable = kernelAvailable;
+      cell.isKernelSessionAvailable = isKernelSessionAvailable;
     } else {
-      cells.set(id, {kernelAvailable});
+      cells.set(id, {isKernelSessionAvailable});
     }
-    const areAllCellsReady = areAllSessionsAvailable(cells);
-    set((cell: CellState) => ({ cells, areAllCellsReady }));
+    const areAllKernelSessionsReady = areAllKernelSessionsAvailable(cells);
+    set((cell: CellState) => ({ cells, areAllKernelSessionsReady }));
   },
   setAdapter: (id: string, adapter?: CellAdapter) => {
     const cells = get().cells;
@@ -104,8 +104,8 @@ export const cellStore = createStore<CellState>((set, get) => ({
   getOutputsCount: (id: string): number | undefined => {
     return get().cells.get(id)?.outputsCount;
   },
-  getIsKernelAvailable: (id: string): boolean | undefined => {
-    return get().cells.get(id)?.kernelAvailable;
+  getIsKernelSessionAvailable: (id: string): boolean | undefined => {
+    return get().cells.get(id)?.isKernelSessionAvailable;
   },
   execute: (id: string) => { 
     const cells = get().cells;

--- a/packages/react/src/components/cell/CellState.ts
+++ b/packages/react/src/components/cell/CellState.ts
@@ -12,22 +12,23 @@ export interface ICellState {
   source?: string;
   outputsCount?: number;
   adapter?: CellAdapter;
+  kernelAvailable?: boolean;
 }
 
 export interface ICellsState {
   cells: Map<string, ICellState>;
-  kernelAvailable: boolean; // Currently shared between all cells
 }
 
 export type CellState = ICellsState & {
   setCells: (cells: Map<string, ICellState>) => void;
   setSource: (id: string, source: string) => void;
   setOutputsCount: (id: string, outputsCount: number) => void;
-  setKernelAvailable: (kernelAvailable: boolean) => void;
+  setKernelAvailable: (id: string, kernelAvailable: boolean) => void;
   setAdapter: (id: string, adapter?: CellAdapter) => void;
   getAdapter: (id: string) => CellAdapter | undefined;
   getSource: (id: string) => string | undefined;
   getOutputsCount: (id: string) => number | undefined;
+  getIsKernelAvaiable: (id: string) => boolean | undefined;
   execute: (id?: string) => void;
 };
 
@@ -59,7 +60,16 @@ export const cellStore = createStore<CellState>((set, get) => ({
     }
     set((state: CellState) => ({ cells }))
   },
-  setKernelAvailable: (kernelAvailable: boolean) => set((state: CellState) => ({ kernelAvailable })),
+  setKernelAvailable: (id: string, kernelAvailable: boolean) => {
+    const cells = get().cells;
+    const cell = cells.get(id);
+    if (cell) {
+      cell.kernelAvailable = kernelAvailable;
+    } else {
+      cells.set(id, {kernelAvailable});
+    }
+    set((cell: CellState) => ({ cells }))
+  },
   setAdapter: (id: string, adapter?: CellAdapter) => {
     const cells = get().cells;
     const cell = cells.get(id);
@@ -78,6 +88,9 @@ export const cellStore = createStore<CellState>((set, get) => ({
   },
   getOutputsCount: (id: string): number | undefined => {
     return get().cells.get(id)?.outputsCount;
+  },
+  getIsKernelAvaiable: (id: string): boolean | undefined => {
+    return get().cells.get(id)?.kernelAvailable;
   },
   execute: (id: string) => { 
     const cells = get().cells;

--- a/packages/react/src/examples/All.tsx
+++ b/packages/react/src/examples/All.tsx
@@ -58,7 +58,7 @@ const CellPreview = (props: ICellToolProps) => {
   return (
     <>
       <>source: {cellStore.getSource(props.id)}</>
-      <>kernel available: {String(cellStore.getIsKernelAvailable(props.id))}</>
+      <>kernel available: {String(cellStore.getIsKernelSessionAvailable(props.id))}</>
     </>
   );
 };

--- a/packages/react/src/examples/All.tsx
+++ b/packages/react/src/examples/All.tsx
@@ -58,7 +58,7 @@ const CellPreview = (props: ICellToolProps) => {
   return (
     <>
       <>source: {cellStore.getSource(props.id)}</>
-      <>kernel available: {String(cellStore.kernelAvailable)}</>
+      <>kernel available: {String(cellStore.getIsKernelAvaiable(props.id))}</>
     </>
   );
 };

--- a/packages/react/src/examples/All.tsx
+++ b/packages/react/src/examples/All.tsx
@@ -58,7 +58,7 @@ const CellPreview = (props: ICellToolProps) => {
   return (
     <>
       <>source: {cellStore.getSource(props.id)}</>
-      <>kernel available: {String(cellStore.getIsKernelAvaiable(props.id))}</>
+      <>kernel available: {String(cellStore.getIsKernelAvailable(props.id))}</>
     </>
   );
 };

--- a/packages/react/src/examples/Notebook.tsx
+++ b/packages/react/src/examples/Notebook.tsx
@@ -3,6 +3,7 @@
  *
  * MIT License
  */
+
 import { createRoot } from 'react-dom/client';
 import Jupyter from '../jupyter/Jupyter';
 import Notebook from '../components/notebook/Notebook';

--- a/packages/react/src/examples/Notebook.tsx
+++ b/packages/react/src/examples/Notebook.tsx
@@ -3,7 +3,6 @@
  *
  * MIT License
  */
-
 import { createRoot } from 'react-dom/client';
 import Jupyter from '../jupyter/Jupyter';
 import Notebook from '../components/notebook/Notebook';


### PR DESCRIPTION
- Added an event to detect when kernel exists and is `connected` and moved isKernelAvaiable control for each cell;
- Added the `areAllCellsReady` flag which determines when the `isKernelAvailable` of all cells is `true`;
- Moved the definition of `isKernelAvailable` to an event where the kernel is guaranteed to be available and connected, and which is independent of `autoStart: true`;
- Added a null safety check for a JS error for the following snippet: `this._cell.model.mimeType = mimeType`;