### PR TITLE
Control when a Cell is executing #279

### DIFF
--- a/packages/react/src/components/cell/Cell.tsx
+++ b/packages/react/src/components/cell/Cell.tsx
@@ -64,15 +64,18 @@ export const Cell = (props: ICellProps) => {
       }
     
       // Perform auto-start for code or markdown cells
+      cellStore.setIsExecuting(id, true);
       if (adapter.cell instanceof CodeCell) {
-        CodeCell.execute(
-          adapter.cell,
-          adapter.sessionContext
-        );
+        CodeCell
+          .execute(adapter.cell, adapter.sessionContext)
+          .then(() => {
+            cellStore.setIsExecuting(id, false);
+          });
       }
 
       if (adapter.cell instanceof MarkdownCell) {
         adapter.cell.rendered = true;
+        cellStore.setIsExecuting(id, false);
       }
     });
 
@@ -88,6 +91,7 @@ export const Cell = (props: ICellProps) => {
     if (id && defaultKernel && serverSettings) {
       defaultKernel.ready.then(() => {
         const adapter = new CellAdapter({
+          id,
           type,
           source,
           serverSettings,

--- a/packages/react/src/components/cell/CellAdapter.ts
+++ b/packages/react/src/components/cell/CellAdapter.ts
@@ -318,9 +318,9 @@ export class CellAdapter {
       icon: runIcon,
       onClick: () => {
         cellStore.getState().setIsExecuting(this._id, true);
-        if (this._cell instanceof CodeCell) {
+        if (this._type === 'code') {
           CodeCell
-            .execute(this._cell, this._sessionContext)
+            .execute((this._cell as CodeCell), this._sessionContext)
             .then(() => {
               cellStore.getState().setIsExecuting(this._id, false);
             });

--- a/packages/react/src/components/cell/CellCommands.ts
+++ b/packages/react/src/components/cell/CellCommands.ts
@@ -20,7 +20,7 @@ export const CellCommands = (
   commandRegistry: CommandRegistry,
   cell: CodeCell | MarkdownCell | RawCell,
   sessionContext: SessionContext,
-  completerHandler: CompletionHandler,
+  completerHandler: CompletionHandler
 ): void => {
   commandRegistry.addCommand(cmdIds.invoke, {
     label: 'Completer: Invoke',

--- a/packages/react/src/components/cell/CellState.ts
+++ b/packages/react/src/components/cell/CellState.ts
@@ -8,29 +8,34 @@ import { createStore } from 'zustand/vanilla';
 import { useStore } from 'zustand';
 import CellAdapter from './CellAdapter';
 
+// Individual, for each cell
 export interface ICellState {
   source?: string;
   outputsCount?: number;
   adapter?: CellAdapter;
-  isKernelSessionAvailable?: boolean; // Individual, for cell
+  isKernelSessionAvailable?: boolean;
+  isExecuting?: boolean;
 }
 
+// For all cells
 export interface ICellsState {
   cells: Map<string, ICellState>;
-  areAllKernelSessionsReady: boolean; // Control the state for all cells
+  areAllKernelSessionsReady: boolean; // Control if all cells has sessions available
+  isAnyCellExecuting: boolean; // Control if at least one cell is executing
 }
 
 export type CellState = ICellsState & {
   setCells: (cells: Map<string, ICellState>) => void;
   setSource: (id: string, source: string) => void;
   setOutputsCount: (id: string, outputsCount: number) => void;
-  setIsKernelSessionAvailable: (id: string, kernelAvailable: boolean) => void;
   setAdapter: (id: string, adapter?: CellAdapter) => void;
-  getAdapter: (id: string) => CellAdapter | undefined;
+  setIsKernelSessionAvailable: (id: string, kernelAvailable: boolean) => void;
   getSource: (id: string) => string | undefined;
   getOutputsCount: (id: string) => number | undefined;
+  getAdapter: (id: string) => CellAdapter | undefined;
   getIsKernelSessionAvailable: (id: string) => boolean | undefined;
   execute: (id?: string) => void;
+  setIsExecuting: (id: string, isExecuting: boolean) => void; // Necessary for the cases when execute directly from jupyterlab/cells
 };
 
 /**
@@ -45,13 +50,27 @@ const areAllKernelSessionsAvailable = (cells: Map<string, ICellState>): boolean 
   return true;
 };
 
+/**
+ * Check if any cell is currently executing
+ */
+export const isAnyCellRunning = (cells: Map<string, ICellState>): boolean => {
+  for (const cell of cells.values()) {
+    if (cell.isExecuting) {
+      return true;
+    }
+  }
+  return false;
+};
+
 export const cellStore = createStore<CellState>((set, get) => ({
   cells: new Map<string, ICellState>(),
   source: '',
   outputsCount: 0,
-  isKernelSessionAvailable: false,
-  areAllKernelSessionsReady: false,
   adapter: undefined,
+  isKernelSessionAvailable: false,
+  isExecuting: false,
+  areAllKernelSessionsReady: false, // prop refers to all cells
+  isAnyCellExecuting: false, // prop refers to all cells
   setCells: (cells: Map<string, ICellState>) => set((cell: CellState) => ({ cells })),
 
   setSource: (id: string, source: string) => {
@@ -111,10 +130,32 @@ export const cellStore = createStore<CellState>((set, get) => ({
     const cells = get().cells;
     const cell = cells.get(id);
     if (cell) {
-      cell.adapter?.execute() 
+      cell.adapter?.execute();
+      cell.isExecuting = true;
     } else {
-      get().cells.forEach((cell) => cell.adapter?.execute())
+      get().cells.forEach((cell) => {
+        cell.adapter?.execute();
+        cell.isExecuting = true;
+      });
     }
+    const isAnyCellExecuting = isAnyCellRunning(cells);
+    set((state: CellState) => ({ cells, isAnyCellExecuting }));
+  },
+  setIsExecuting: (id: string, isExecuting: boolean) => {
+    /**
+     * Set is executing
+     * This is necessary to update state in cases when we execute directly from jupyterlab/cells
+     */
+    const cells = get().cells;
+    const cell = cells.get(id);
+    if (cell) {
+      cell.isExecuting = isExecuting;
+    } else {
+      cells.set(id, { isExecuting });
+    }
+
+    const isAnyCellExecuting = isAnyCellRunning(cells);
+    set((state: CellState) => ({ cells, isAnyCellExecuting }));
   },
 }));
 

--- a/packages/react/src/components/cell/CellState.ts
+++ b/packages/react/src/components/cell/CellState.ts
@@ -131,15 +131,12 @@ export const cellStore = createStore<CellState>((set, get) => ({
     const cell = cells.get(id);
     if (cell) {
       cell.adapter?.execute();
-      cell.isExecuting = true;
     } else {
       get().cells.forEach((cell) => {
         cell.adapter?.execute();
-        cell.isExecuting = true;
       });
     }
-    const isAnyCellExecuting = isAnyCellRunning(cells);
-    set((state: CellState) => ({ cells, isAnyCellExecuting }));
+    set((state: CellState) => ({ cells }));
   },
   setIsExecuting: (id: string, isExecuting: boolean) => {
     /**


### PR DESCRIPTION
Implements the proposed solution for the described scenario in #279 issue.

- Added the `isExecuting` attribute in `CellState` to track/control when a cell is executing;
- Also added `isAnyCellExecuting` to the cells map to control if there is any execution in progress (or if all cells are `idle`);
- Improved related comments;
- Improved the order of `CellState` attributes (individual cell attributes first, others for all cells last);
- Updated `CellAdapter` and `CellCommands` to receive the `cellId` in order to update the `isExecuting` state.