### PR TITLE
fix: typo

### DIFF
--- a/packages/react/src/components/notebook/NotebookAdapter.ts
+++ b/packages/react/src/components/notebook/NotebookAdapter.ts
@@ -518,7 +518,7 @@ export class NotebookAdapter {
   setNbformat(nbformat: INotebookContent) {
     if (nbformat === null) {
       throw new Error(
-        'The nformat should first be set via the constructor of NotebookAdapater'
+        'The nbformat should first be set via the constructor of NotebookAdapater'
       );
     }
     this._nbformat = nbformat;


### PR DESCRIPTION
As reported by @mattmutt on https://github.com/datalayer/jupyter-ui/commit/d9b07e0bed7005d76097601a36a349ddd1e09d2d