### PR TITLE
[v2] Control when a Cell is executing #279

### DIFF
--- a/packages/react/src/components/cell/CellAdapter.ts
+++ b/packages/react/src/components/cell/CellAdapter.ts
@@ -485,6 +485,7 @@ export class CellAdapter {
       cellsStore.getState().setIsExecuting(this._id, false);
       return executeReplyMessage;
     } catch (e) {
+      cellsStore.getState().setIsExecuting(this._id, false);
       // If we started executing, and the cell is still indicating this execution, clear the prompt.
       if (future && !cell.isDisposed && cell.outputArea.future === future) {
         cell.setPrompt('');
@@ -498,7 +499,6 @@ export class CellAdapter {
           model.setMetadata('execution', timingInfo);
         }
       }
-      cellsStore.getState().setIsExecuting(this._id, false);
       throw e;
     }
   }

--- a/packages/react/src/examples/CellExecuteControl.tsx
+++ b/packages/react/src/examples/CellExecuteControl.tsx
@@ -22,10 +22,7 @@ const btnStyle = {
     marginTop: '20px'
 }
 
-const CELL_CODE = `
-import time
-time.sleep(10)
-`
+const CELL_CODE = `import time\ntime.sleep(3)`
 
 const CellExecuteControl = () => {
   const [executionDisable, setExecutionDisable] = React.useState(false);
@@ -50,13 +47,13 @@ const CellExecuteControl = () => {
       <Box style={{marginTop: '20px'}}>
         <Cell 
           id='1' 
-          type={'code'} 
+          type='code'
           source={CELL_CODE} 
           autoStart={false} 
           showToolbar={false} />
         <Cell 
           id='2' 
-          type={'code'} 
+          type='code'
           autoStart={false} 
           showToolbar={false} />
         <Button 

--- a/packages/react/src/examples/CellExecuteControl.tsx
+++ b/packages/react/src/examples/CellExecuteControl.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2021-2023 Datalayer, Inc.
+ *
+ * MIT License
+ */
+import React, {useEffect} from 'react';
+import { createRoot } from 'react-dom/client';
+
+import {Button, Box} from '@primer/react';
+
+import Jupyter from '../jupyter/Jupyter';
+import Cell from '../components/cell/Cell';
+import { cellsStore, ICellsState } from '../components/cell/CellState';
+
+
+const div = document.createElement('div');
+document.body.appendChild(div);
+const root = createRoot(div);
+
+const btnStyle = {
+    marginLeft: '50px',
+    marginTop: '20px'
+}
+
+const CELL_CODE = `
+import time
+time.sleep(10)
+`
+
+const CellExecuteControl = () => {
+  const [executionDisable, setExecutionDisable] = React.useState(false);
+
+  useEffect(() => {
+    const handleChange = (newState: ICellsState) => {
+      setExecutionDisable(newState.isAnyCellExecuting);
+    };
+
+    const unsubscribe = cellsStore.subscribe(handleChange);
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  const onExecuteClick = () => {
+    cellsStore.getState().execute();
+  }
+
+  return (
+    <Jupyter>
+      <Box style={{marginTop: '20px'}}>
+        <Cell 
+          id='1' 
+          type={'code'} 
+          source={CELL_CODE} 
+          autoStart={false} 
+          showToolbar={false} />
+        <Cell 
+          id='2' 
+          type={'code'} 
+          autoStart={false} 
+          showToolbar={false} />
+        <Button 
+          onClick={onExecuteClick} 
+          disabled={executionDisable} 
+          style={btnStyle}>Execute all</Button>
+      </Box>
+    </Jupyter>
+  )
+};
+
+root.render(<CellExecuteControl/>);

--- a/packages/react/src/jupyter/kernel/KernelExecutor.ts
+++ b/packages/react/src/jupyter/kernel/KernelExecutor.ts
@@ -258,13 +258,9 @@ export class KernelExecutor {
           break;
         case 'error':
           {
-            // NOTE: This block that was here previously cannot extract the properties consistently, 
-            //causing the Promise to never be rejected in case of an execution error.
-            // const { ename, evalue, traceback } = (
-            //   content as any as KernelMessage.IErrorMsg
-            // ).content;
+            const { ename, evalue, traceback } = content as KernelMessage.IReplyErrorContent;
             this._executed.reject(
-              `${content.ename}: ${content.evalue}\n${(content.traceback ?? []).join('\n')}`
+              `${ename}: ${evalue}\n${(traceback ?? []).join('\n')}`
             );
           }
           break;

--- a/packages/react/src/jupyter/kernel/KernelExecutor.ts
+++ b/packages/react/src/jupyter/kernel/KernelExecutor.ts
@@ -258,11 +258,13 @@ export class KernelExecutor {
           break;
         case 'error':
           {
-            const { ename, evalue, traceback } = (
-              content as any as KernelMessage.IErrorMsg
-            ).content;
+            // NOTE: This block that was here previously cannot extract the properties consistently, 
+            //causing the Promise to never be rejected in case of an execution error.
+            // const { ename, evalue, traceback } = (
+            //   content as any as KernelMessage.IErrorMsg
+            // ).content;
             this._executed.reject(
-              `${ename}: ${evalue}\n${(traceback ?? []).join('\n')}`
+              `${content.ename}: ${content.evalue}\n${(content.traceback ?? []).join('\n')}`
             );
           }
           break;


### PR DESCRIPTION
* Reimplements the proposed solution for the described scenario in https://github.com/datalayer/jupyter-ui/issues/279 issue (after #282 changes)

* Added the `isExecuting` attribute in `CellState` to track/control when a cell is executing;
* Also added `isAnyCellExecuting` to the cells map to control if there is any execution in progress (or if all cells are `idle`);
* Improved related comments;
* Updated `CellAdapter` to update the `isExecuting` state in new `_execute` generic function;
* Added the `CellExecuteControl.tsx` example.