### PR TITLE
Allow deletion of orphan output nodes!

### DIFF
--- a/packages/lexical/src/convert/markdown/convertToMarkdown.ts
+++ b/packages/lexical/src/convert/markdown/convertToMarkdown.ts
@@ -25,7 +25,7 @@ import {
 } from './utils';
 
 export function $convertToMarkdownString(): string {
-  const output = [];
+  const output: string[] = [];
   const children = $getRoot().getChildren();
 
   for (const child of children) {
@@ -56,7 +56,7 @@ function exportTopLevelElementOrDecorator(node: LexicalNode): string | null {
 }
 
 function exportChildren(node: ElementNode): string {
-  const output = [];
+  const output: string[] = [];
   const children = node.getChildren();
 
   for (const child of children) {

--- a/packages/lexical/src/nodes/JupyterOutputNodeUtils.ts
+++ b/packages/lexical/src/nodes/JupyterOutputNodeUtils.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021-2023 Datalayer, Inc.
+ *
+ * MIT License
+ */
+
+import { INPUT_UUID_TO_CODE_KEY } from '../plugins/JupyterInputOutputPlugin';
+import type { JupyterOutputNode } from './JupyterOutputNode';
+
+/**
+ * Check if a JupyterOutputNode is orphaned (its parent input node was deleted).
+ *
+ * An output node is considered orphaned if:
+ * 1. Its parent input node UUID is not in the INPUT_UUID_TO_CODE_KEY map, OR
+ * 2. The output node has no parent in the Lexical tree
+ *
+ * @param outputNode - The JupyterOutputNode to check
+ * @returns true if the output node is orphaned, false otherwise
+ */
+export function isJupyterOutputNodeOrphaned(
+  outputNode: JupyterOutputNode,
+): boolean {
+  const inputNodeKey = INPUT_UUID_TO_CODE_KEY.get(
+    outputNode.getJupyterInputNodeUuid(),
+  );
+  return !inputNodeKey || !outputNode.getParent();
+}


### PR DESCRIPTION
Fixes https://github.com/datalayer/vscode-datalayer/issues/28

So, maybe something still needs to be fixed on lexical loro side, but this allows selection and deletion of orphaned output cells which is what the bug manifested as.

We should probably not get to this state in the first place, but at least this allows to delete the orphan output nodes for documents that resulted in this.